### PR TITLE
fix: resolve header overlap on submit page mobile Safari

### DIFF
--- a/src/components/project/ProjectForm.tsx
+++ b/src/components/project/ProjectForm.tsx
@@ -87,7 +87,7 @@ export function ProjectForm({ onSuccess, onCancel }: ProjectFormProps) {
   }
 
   return (
-    <div className="max-w-2xl mx-auto p-6">
+    <div className="max-w-2xl mx-auto p-6 pt-24 sm:pt-28">
       <div className="mb-6">
         <h1 className="text-3xl font-bold text-uiuc-blue mb-2">Submit Your Project</h1>
         <p className="text-gray-600">Share your amazing work with the Illinois community!</p>


### PR DESCRIPTION
Fixes header overlap issue on the submit page for mobile Safari

## Changes
- Added responsive top padding to ProjectForm container
- pt-24 (96px) on mobile, pt-28 (112px) on desktop
- Ensures proper spacing between fixed header and page content

## Testing
- Tested on mobile Safari viewport sizes
- Verified no overlap between header and page content
- Maintained responsive design across screen sizes

Closes #7

Generated with [Claude Code](https://claude.ai/code)