### PR TITLE
fix(ui): improve banner tagline integration in hero section

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -107,10 +107,12 @@ export function HomePage() {
         <div className="relative z-10 container mx-auto px-4 min-h-screen flex items-center">
           <div className="text-center w-full py-20">
             
-            {/* Badge */}
-            <div className="inline-flex items-center gap-2 bg-uiuc-orange/20 border border-uiuc-orange/30 rounded-full px-4 py-2 mb-6 sm:mb-8">
-              <Zap className="w-4 h-4 text-uiuc-orange" />
-              <span className="text-white font-medium text-sm sm:text-base">Where Illini Ideas Come to Life</span>
+            {/* Integrated Tagline */}
+            <div className="mb-4 sm:mb-6">
+              <div className="inline-flex items-center gap-2 text-uiuc-orange mb-3 sm:mb-4">
+                <Zap className="w-5 h-5 sm:w-6 sm:h-6" />
+                <span className="text-lg sm:text-xl lg:text-2xl font-semibold tracking-wide">Where Illini Ideas Come to Life</span>
+              </div>
             </div>
             
             {/* Main Heading */}


### PR DESCRIPTION
This PR fixes the banner alignment issue where the tagline "⚡ Where Illini Ideas Come to Life" appeared disconnected from the hero section.

## Changes
- Removed disconnected pill-style badge design
- Integrated tagline as proper lead-in to main heading
- Improved font size and visual hierarchy
- Enhanced UIUC brand consistency
- Cleaner design with better spacing

Fixes #10

Generated with [Claude Code](https://claude.ai/code)