### PR TITLE
Fix dashboard authentication race condition

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,13 +58,9 @@ const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
   const location = useLocation()
   const { showAuthPrompt } = useAuthPrompt()
 
-  // For protected routes, we need to wait for auth to complete
-  // But check if there's a stored session to minimize loading time
-  const hasStoredAuth = typeof window !== 'undefined' && 
-    window.localStorage.getItem('illinihunt-auth') !== null
-
-  // Only show loading for protected routes if no stored auth
-  if (loading && !hasStoredAuth) {
+  // Always wait for authentication to complete, regardless of localStorage
+  // This prevents race conditions during OAuth callbacks and session establishment
+  if (loading) {
     return (
       <div className="min-h-screen bg-background flex items-center justify-center">
         <div className="text-center">
@@ -76,7 +72,7 @@ const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
   }
 
   // Redirect to home if not authenticated after loading completes
-  if (!user && !loading) {
+  if (!user) {
     // Show auth prompt for non-home routes
     if (location.pathname !== '/') {
       showAuthPrompt('access this page')

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -14,10 +14,6 @@ interface AuthState {
 }
 
 export function useAuth() {
-  // Check if we potentially have a session to minimize loading flash
-  const hasStoredSession = typeof window !== 'undefined' && 
-    window.localStorage.getItem('illinihunt-auth') !== null
-
   const [state, setState] = useState<AuthState>({
     user: null,
     profile: null,

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -22,7 +22,7 @@ export function useAuth() {
     user: null,
     profile: null,
     session: null,
-    loading: !hasStoredSession, // If no stored session, we know we need to show loading
+    loading: true, // Always start with loading to ensure proper auth check
     error: null
   })
 


### PR DESCRIPTION
Fixes #14

This PR resolves the dashboard authentication bug where users were prompted to authenticate again after successful sign-in.

## Changes
- Fixed race condition in ProtectedRoute component
- Improved authentication state initialization in useAuth hook
- Ensures proper OAuth callback handling

## Testing
- TypeScript compilation passes
- Build process completes successfully
- Authentication flow logic verified

Generated with [Claude Code](https://claude.ai/code)