### PR TITLE
feat: improve placeholder svg accessibility

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -189,14 +189,16 @@ export function HomePage() {
                             />
                           ) : (
                             <div className="w-16 h-16 bg-gradient-to-br from-uiuc-orange to-uiuc-blue rounded-xl flex items-center justify-center border border-white/20 shadow-sm">
-                              <svg className="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z" />
-                              </svg>
+                              <span role="img" aria-label="Project placeholder icon">
+                                <svg className="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z" />
+                                </svg>
+                              </span>
                             </div>
                           )}
                           {/* Upvote Badge */}
                           <div className="flex items-center gap-1.5 bg-uiuc-orange/20 border border-uiuc-orange/30 rounded-full px-3 py-1.5">
-                            <svg className="w-4 h-4 text-uiuc-orange" fill="currentColor" viewBox="0 0 20 20">
+                            <svg className="w-4 h-4 text-uiuc-orange" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
                               <path fillRule="evenodd" d="M3.293 9.707a1 1 0 010-1.414l6-6a1 1 0 011.414 0l6 6a1 1 0 01-1.414 1.414L11 5.414V17a1 1 0 11-2 0V5.414L4.707 9.707a1 1 0 01-1.414 0z" clipRule="evenodd" />
                             </svg>
                             <span className="text-sm font-semibold text-uiuc-orange">{project.upvotes_count}</span>


### PR DESCRIPTION
## Summary
- wrap project placeholder SVG with accessible `span` and label
- hide decorative upvote icon from assistive tech

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint found too many warnings)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_68956f13735c832381c8af286b6fe1f6