### PR TITLE
feat: add floating GitHub popup button in bottom-right corner

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { ErrorProvider } from '@/contexts/ErrorContext'
 import { ErrorBoundary } from '@/components/ErrorBoundary'
 import { AuthProvider } from '@/contexts/AuthContext'
 import { RealtimeVotesProvider } from '@/contexts/RealtimeVotesContext'
+import { GitHubPopupButton } from '@/components/GitHubPopupButton'
 
 // Lazy load all pages for code splitting
 const HomePage = lazy(() => import('@/pages/HomePage').then(module => ({ default: module.HomePage })))
@@ -212,6 +213,7 @@ function App() {
             <AuthPromptProvider>
               <RealtimeVotesProvider>
                 <AppContent />
+                <GitHubPopupButton />
                 <SpeedInsights />
                 <Toaster
                   position="top-right"

--- a/src/components/GitHubPopupButton.tsx
+++ b/src/components/GitHubPopupButton.tsx
@@ -1,0 +1,20 @@
+import { Github } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+export function GitHubPopupButton() {
+  const handleClick = () => {
+    window.open('https://github.com/vishalsachdev/illinihunt', '_blank', 'noopener,noreferrer')
+  }
+
+  return (
+    <Button
+      onClick={handleClick}
+      className="fixed bottom-4 right-4 sm:bottom-6 sm:right-6 z-50 h-11 w-11 sm:h-12 sm:w-12 rounded-full bg-uiuc-blue hover:bg-uiuc-orange shadow-lg hover:shadow-xl transition-all duration-200 border-0 focus:ring-2 focus:ring-uiuc-orange focus:ring-offset-2"
+      size="icon"
+      aria-label="Visit GitHub Repository"
+      title="Visit GitHub Repository"
+    >
+      <Github className="h-4 w-4 sm:h-5 sm:w-5 text-white" />
+    </Button>
+  )
+}


### PR DESCRIPTION
Implements # 38 - Add bottom-right floating popup button to hyperlink to the GitHub repo

## Changes
- Add GitHubPopupButton component with UIUC blue/orange styling
- Position as fixed floating button in bottom-right corner
- Responsive design (smaller on mobile, larger on desktop)
- Proper accessibility with ARIA labels and focus states
- Opens GitHub repository in new tab with security attributes
- Integrates with existing shadcn/ui and Tailwind design system

## Testing
- Component follows established patterns from existing codebase
- Uses same GitHub icon and styling patterns as other components
- Responsive design tested across mobile and desktop breakpoints

Generated with [Claude Code](https://claude.ai/code)