### PR TITLE
fix: make project names clickable in dashboard

### DIFF
--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -315,7 +315,12 @@ export function DashboardPage() {
                         <div className="flex items-start justify-between mb-2">
                           <div className="flex-1">
                             <h3 className="text-lg font-semibold text-gray-900 mb-1">
-                              {project.name}
+                              <Link 
+                                to={`/project/${project.id}`}
+                                className="hover:text-uiuc-orange transition-colors cursor-pointer"
+                              >
+                                {project.name}
+                              </Link>
                             </h3>
                             <p className="text-gray-600 mb-2 line-clamp-2">
                               {project.tagline}


### PR DESCRIPTION
Fixes #46

## Summary
- Project names in the dashboard are now clickable and navigate to project detail pages
- Added hover effect with UIUC orange color for better UX
- Maintains existing styling while adding navigation functionality

## Test Plan
- [ ] Sign in to the application
- [ ] Navigate to the dashboard page
- [ ] Verify project names are now clickable (cursor changes on hover)
- [ ] Click on a project name and verify it navigates to the project detail page
- [ ] Verify hover effect shows orange color transition

🤖 Generated with [Claude Code](https://claude.ai/code)