### PR TITLE
feat: make navbar sticky to float on top during scroll

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -119,7 +119,7 @@ function AppContent() {
 
   return (
     <div className="min-h-screen bg-background">
-        <header className="absolute top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b text-gray-900 p-4 shadow-sm">
+        <header className="sticky top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b text-gray-900 p-4 shadow-sm">
           <div className="container mx-auto flex items-center justify-between">
             <div className="flex-shrink-0">
               <Link to="/" className="block">


### PR DESCRIPTION
This PR implements a sticky navbar that floats at the top during scrolling.

## Changes
- Changed navbar positioning from `absolute` to `sticky` in src/App.tsx
- Navbar now stays at the top when scrolling on homepage
- Maintains existing visual styling and backdrop blur effect

## Testing
The sticky navbar:
1. Stays at the top of the viewport when scrolling
2. Maintains its visual styling (semi-transparent with backdrop blur)
3. Works across all pages without layout issues

Resolves #55

Generated with [Claude Code](https://claude.ai/code)