### PR TITLE
fix(projects): defer image upload to submit; staged progress; inline errors

### DIFF
--- a/src/components/project/ProjectForm.tsx
+++ b/src/components/project/ProjectForm.tsx
@@ -149,7 +149,25 @@ export function ProjectForm({ mode = 'create', projectId, initialData, onSuccess
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Something went wrong'
       setSubmitError(`${message} — your form is intact, please try again.`)
-      handleFormError(error, `project ${mode === 'edit' ? 'update' : 'submission'}`)
+      handleFormError(
+        error,
+        `project ${mode === 'edit' ? 'update' : 'submission'}`,
+        {
+          stage: stage ?? 'unknown',
+          mode,
+          projectId: mode === 'edit' ? projectId : undefined,
+          imageKind: image.kind,
+          // For pending picks, log size/type/name so we can correlate failures
+          // with file characteristics (e.g., specific MIME, very large source).
+          imageType: image.kind === 'pending' ? image.file.type : undefined,
+          imageSizeBytes: image.kind === 'pending' ? image.file.size : undefined,
+          imageNameExt: image.kind === 'pending'
+            ? image.file.name.split('.').pop()?.toLowerCase()
+            : undefined,
+          // Whether the user already had a server-stored image at submit time
+          hadExistingImage: image.kind === 'existing' || image.kind === 'cleared',
+        }
+      )
     } finally {
       setIsSubmitting(false)
       setStage(null)

--- a/src/components/project/ProjectForm.tsx
+++ b/src/components/project/ProjectForm.tsx
@@ -1,10 +1,12 @@
 import { useState, useEffect } from 'react'
 import { useForm, Controller } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
+import { AlertCircle } from 'lucide-react'
 import { useAuth } from '@/hooks/useAuth'
 import { useCategories } from '@/hooks/useCategories'
 import { useError } from '@/contexts/ErrorContext'
 import { ProjectsService } from '@/lib/database'
+import { compressImage, uploadProjectImage } from '@/lib/imageUpload'
 import { projectSchema, type ProjectFormData } from '@/lib/validations'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -17,7 +19,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { ImageUpload } from '@/components/ui/ImageUpload'
+import { ImageUpload, type ImagePickerValue } from '@/components/ui/ImageUpload'
 import { CategoryIcon } from '@/lib/categoryIcons'
 import type { Database } from '@/types/database'
 
@@ -31,19 +33,40 @@ interface ProjectFormProps {
   onCancel?: () => void
 }
 
+type SubmitStage = 'compressing' | 'uploading' | 'saving'
+
+const STAGE_LABEL: Record<SubmitStage, string> = {
+  compressing: 'Preparing image…',
+  uploading: 'Uploading image…',
+  saving: 'Saving project…',
+}
+
+const FIELD_LABEL: Record<keyof ProjectFormData, string> = {
+  name: 'project name',
+  tagline: 'tagline',
+  description: 'description',
+  category_id: 'category',
+  website_url: 'website URL',
+  github_url: 'GitHub URL',
+  video_url: 'YouTube URL',
+  image_url: 'image',
+}
+
 export function ProjectForm({ mode = 'create', projectId, initialData, onSuccess, onCancel }: ProjectFormProps) {
   const { user } = useAuth()
   const { categories, loading: loadingCategories } = useCategories()
   const { handleFormError, handleAuthError, showSuccess } = useError()
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [imageUrl, setImageUrl] = useState<string>('')
+  const [stage, setStage] = useState<SubmitStage | null>(null)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [image, setImage] = useState<ImagePickerValue>({ kind: 'empty' })
 
   const {
     register,
     handleSubmit,
     reset,
     control,
-    formState: { errors }
+    formState: { errors, submitCount }
   } = useForm<ProjectFormData>({
     resolver: zodResolver(projectSchema)
   })
@@ -60,7 +83,11 @@ export function ProjectForm({ mode = 'create', projectId, initialData, onSuccess
         github_url: initialData.github_url || '',
         video_url: initialData.video_url || ''
       })
-      setImageUrl(initialData.image_url || '')
+      setImage(
+        initialData.image_url
+          ? { kind: 'existing', url: initialData.image_url }
+          : { kind: 'empty' }
+      )
     }
   }, [mode, initialData, reset])
 
@@ -70,14 +97,34 @@ export function ProjectForm({ mode = 'create', projectId, initialData, onSuccess
       return
     }
 
+    setSubmitError(null)
     setIsSubmitting(true)
-    
+    setStage(null)
+
     try {
+      // Resolve image_url according to the deferred-upload state machine
+      let imageUrl: string | null = null
+      if (image.kind === 'pending') {
+        setStage('compressing')
+        const compressed = await compressImage(image.file)
+        setStage('uploading')
+        const result = await uploadProjectImage(compressed, user.id)
+        if (result.error || !result.url) {
+          throw new Error(result.error ?? 'Image upload failed')
+        }
+        imageUrl = result.url
+      } else if (image.kind === 'existing') {
+        imageUrl = image.url
+      }
+      // 'empty' or 'cleared' → null
+
+      setStage('saving')
+
       const projectData = {
         ...data,
         website_url: data.website_url || null,
         github_url: data.github_url || null,
-        image_url: imageUrl || null,
+        image_url: imageUrl,
         video_url: data.video_url || null,
       }
 
@@ -92,15 +139,29 @@ export function ProjectForm({ mode = 'create', projectId, initialData, onSuccess
         })
         if (error) throw error
         showSuccess('Project submitted successfully!', 'Your project is now live on IlliniHunt!')
+
+        // After a successful create, the new project's image is now persisted.
+        // Reset the picker so any remaining `pending` File reference is dropped.
+        setImage(imageUrl ? { kind: 'existing', url: imageUrl } : { kind: 'empty' })
       }
 
       onSuccess?.()
     } catch (error) {
+      const message = error instanceof Error ? error.message : 'Something went wrong'
+      setSubmitError(`${message} — your form is intact, please try again.`)
       handleFormError(error, `project ${mode === 'edit' ? 'update' : 'submission'}`)
     } finally {
       setIsSubmitting(false)
+      setStage(null)
     }
   }
+
+  const missingFields = Object.keys(errors) as (keyof ProjectFormData)[]
+  const showMissingHint = submitCount > 0 && missingFields.length > 0 && !isSubmitting
+
+  const submitLabel =
+    stage ? STAGE_LABEL[stage] :
+    mode === 'edit' ? 'Update Project' : 'Submit Project'
 
   return (
     <div className="max-w-2xl mx-auto p-6 pt-24 sm:pt-28">
@@ -109,8 +170,8 @@ export function ProjectForm({ mode = 'create', projectId, initialData, onSuccess
           {mode === 'edit' ? 'Edit Your Project' : 'Submit Your Project'}
         </h1>
         <p className="text-gray-600">
-          {mode === 'edit' 
-            ? 'Update your project details and share your latest improvements with the community!' 
+          {mode === 'edit'
+            ? 'Update your project details and share your latest improvements with the community!'
             : 'Share your amazing work with the Illinois community!'
           }
         </p>
@@ -163,8 +224,8 @@ export function ProjectForm({ mode = 'create', projectId, initialData, onSuccess
               name="category_id"
               control={control}
               render={({ field }) => (
-                <Select 
-                  onValueChange={field.onChange} 
+                <Select
+                  onValueChange={field.onChange}
                   value={field.value || ''}
                   disabled={isSubmitting}
                 >
@@ -175,9 +236,9 @@ export function ProjectForm({ mode = 'create', projectId, initialData, onSuccess
                     {categories.map((category) => (
                       <SelectItem key={category.id} value={category.id}>
                         <div className="flex items-center gap-2">
-                          <CategoryIcon 
-                            iconName={category.icon} 
-                            className="w-4 h-4 flex-shrink-0" 
+                          <CategoryIcon
+                            iconName={category.icon}
+                            className="w-4 h-4 flex-shrink-0"
                             fallback={category.name}
                           />
                           <div className="flex flex-col min-w-0">
@@ -265,29 +326,44 @@ export function ProjectForm({ mode = 'create', projectId, initialData, onSuccess
 
         {/* Image Upload */}
         <ImageUpload
-          onImageUploaded={setImageUrl}
-          onImageRemoved={() => setImageUrl('')}
-          currentImageUrl={imageUrl}
+          value={image}
+          onChange={setImage}
           disabled={isSubmitting}
         />
 
+        {/* Inline submit error — persistent, unlike a toast */}
+        {submitError && (
+          <div className="flex items-start space-x-2 text-sm text-red-700 bg-red-50 border border-red-200 rounded p-3">
+            <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
+            <span>{submitError}</span>
+          </div>
+        )}
+
+        {/* Missing-fields hint shown after the first failed submit attempt */}
+        {showMissingHint && (
+          <div className="text-sm text-amber-800 bg-amber-50 border border-amber-200 rounded p-3">
+            Please complete: {missingFields.map(f => FIELD_LABEL[f]).join(', ')}.
+          </div>
+        )}
+
         {/* Submit Buttons */}
-        <div className="flex gap-3 pt-4">
-          <Button 
-            type="submit" 
+        <div className="flex gap-3 pt-4 items-center">
+          <Button
+            type="submit"
             disabled={isSubmitting}
             className="bg-uiuc-orange hover:bg-uiuc-orange/90"
           >
-            {isSubmitting 
-              ? (mode === 'edit' ? 'Updating...' : 'Submitting...') 
-              : (mode === 'edit' ? 'Update Project' : 'Submit Project')
-            }
+            {isSubmitting && (
+              <span className="inline-block w-4 h-4 mr-2 align-middle border-2 border-white/40 border-t-white rounded-full animate-spin" />
+            )}
+            {submitLabel}
           </Button>
           {onCancel && (
-            <Button 
-              type="button" 
-              variant="outline" 
+            <Button
+              type="button"
+              variant="outline"
               onClick={onCancel}
+              disabled={isSubmitting}
             >
               Cancel
             </Button>

--- a/src/components/ui/ImageUpload.tsx
+++ b/src/components/ui/ImageUpload.tsx
@@ -1,133 +1,125 @@
-import { useState, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Button } from './button'
 import { Input } from './input'
 import { Label } from './label'
 import { Upload, X, AlertCircle } from 'lucide-react'
-import { uploadProjectImage, compressImage, RAW_INPUT_MAX_BYTES, type ImageUploadResult } from '@/lib/imageUpload'
-import { useAuth } from '@/hooks/useAuth'
+import { RAW_INPUT_MAX_BYTES } from '@/lib/imageUpload'
 
-interface ImageUploadProps {
-  onImageUploaded: (url: string) => void
-  onImageRemoved: () => void
-  currentImageUrl?: string
+/**
+ * The image input is a *deferred* picker: it never uploads. The parent
+ * form holds the chosen state and uploads on submit. This makes "image
+ * uploaded" and "project submitted" the same atomic user action and
+ * removes the entire class of "file in storage but no project row" bugs.
+ */
+export type ImagePickerValue =
+  | { kind: 'empty' }
+  | { kind: 'existing'; url: string }   // edit mode — original server URL
+  | { kind: 'pending'; file: File }     // newly picked file, not yet uploaded
+  | { kind: 'cleared' }                 // edit mode — original removed by user
+
+interface ImagePickerProps {
+  value: ImagePickerValue
+  onChange: (next: ImagePickerValue) => void
   disabled?: boolean
 }
 
-export function ImageUpload({ 
-  onImageUploaded, 
-  onImageRemoved, 
-  currentImageUrl, 
-  disabled 
-}: ImageUploadProps) {
-  const { user } = useAuth()
-  const [uploading, setUploading] = useState(false)
+const ALLOWED_TYPES = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp', 'image/gif']
+
+export function ImageUpload({ value, onChange, disabled }: ImagePickerProps) {
   const [dragOver, setDragOver] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [pickError, setPickError] = useState<string | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
-  const handleFileSelect = async (file: File) => {
-    if (!user) {
-      setError('You must be logged in to upload images')
+  // Manage object URL for pending File previews; revoke on change/unmount
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null)
+  useEffect(() => {
+    if (value.kind === 'pending') {
+      const url = URL.createObjectURL(value.file)
+      setPreviewUrl(url)
+      return () => URL.revokeObjectURL(url)
+    }
+    setPreviewUrl(null)
+  }, [value])
+
+  const validateAndPick = (file: File) => {
+    setPickError(null)
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      setPickError('Please choose a JPG, PNG, WebP, or GIF.')
       return
     }
-
     if (file.size > RAW_INPUT_MAX_BYTES) {
       const mb = Math.round(RAW_INPUT_MAX_BYTES / (1024 * 1024))
-      setError(`Image is too large. Please choose a file under ${mb} MB — it will be compressed automatically before upload.`)
+      setPickError(`Image is too large. Please choose a file under ${mb} MB — it will be compressed automatically when you submit.`)
       return
     }
-
-    setUploading(true)
-    setError(null)
-
-    try {
-      // Compress large images
-      const compressedFile = await compressImage(file)
-      
-      // Upload to Supabase
-      const result: ImageUploadResult = await uploadProjectImage(compressedFile, user.id)
-      
-      if (result.error) {
-        setError(result.error)
-      } else if (result.url) {
-        onImageUploaded(result.url)
-      } else {
-        setError('Upload completed but no URL returned')
-      }
-    } catch (err) {
-      setError(`Upload failed: ${err instanceof Error ? err.message : 'Unknown error'}`)
-    } finally {
-      setUploading(false)
-    }
+    onChange({ kind: 'pending', file })
   }
 
   const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
-    if (file) {
-      handleFileSelect(file)
-    }
+    if (file) validateAndPick(file)
   }
 
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault()
     setDragOver(false)
-    
     const file = e.dataTransfer.files[0]
     if (file && file.type.startsWith('image/')) {
-      handleFileSelect(file)
+      validateAndPick(file)
     } else {
-      setError('Please drop a valid image file')
+      setPickError('Please drop a valid image file.')
     }
   }
 
-  const handleDragOver = (e: React.DragEvent) => {
-    e.preventDefault()
-    setDragOver(true)
-  }
-
-  const handleDragLeave = (e: React.DragEvent) => {
-    e.preventDefault()
-    setDragOver(false)
-  }
-
-  const openFileDialog = () => {
-    fileInputRef.current?.click()
-  }
-
-  const removeImage = () => {
-    onImageRemoved()
-    if (fileInputRef.current) {
-      fileInputRef.current.value = ''
+  const handleRemove = () => {
+    setPickError(null)
+    if (fileInputRef.current) fileInputRef.current.value = ''
+    if (value.kind === 'existing') {
+      // Edit mode: signal the server-stored image should be cleared on submit
+      onChange({ kind: 'cleared' })
+    } else {
+      onChange({ kind: 'empty' })
     }
   }
+
+  // Display URL: object URL for pending File, server URL for existing
+  const displayUrl =
+    value.kind === 'pending' ? previewUrl :
+    value.kind === 'existing' ? value.url :
+    null
+
+  const isPending = value.kind === 'pending'
 
   return (
     <div className="space-y-2">
       <Label>Project Screenshot/Logo</Label>
-      
-      {currentImageUrl ? (
-        // Show current image with remove option
+
+      {displayUrl ? (
         <div className="relative">
           <div className="border rounded-lg overflow-hidden">
-            <img 
-              src={currentImageUrl} 
-              alt="Project preview" 
+            <img
+              src={displayUrl}
+              alt="Project preview"
               className="w-full h-48 object-cover"
             />
           </div>
+          {isPending && (
+            <div className="absolute bottom-2 left-2 bg-black/70 text-white text-xs rounded px-2 py-1">
+              Will upload when you submit
+            </div>
+          )}
           <Button
             type="button"
             variant="destructive"
             size="sm"
             className="absolute top-2 right-2"
-            onClick={removeImage}
-            disabled={disabled || uploading}
+            onClick={handleRemove}
+            disabled={disabled}
           >
             <X className="w-4 h-4" />
           </Button>
         </div>
       ) : (
-        // Show upload area
         <div
           className={`
             border-2 border-dashed rounded-lg p-6 text-center cursor-pointer transition-colors
@@ -135,52 +127,39 @@ export function ImageUpload({
             ${disabled ? 'opacity-50 cursor-not-allowed' : ''}
           `}
           onDrop={handleDrop}
-          onDragOver={handleDragOver}
-          onDragLeave={handleDragLeave}
-          onClick={!disabled ? openFileDialog : undefined}
+          onDragOver={(e) => { e.preventDefault(); setDragOver(true) }}
+          onDragLeave={(e) => { e.preventDefault(); setDragOver(false) }}
+          onClick={!disabled ? () => fileInputRef.current?.click() : undefined}
         >
-          {uploading ? (
-            <div className="flex flex-col items-center space-y-2">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-uiuc-orange"></div>
-              <p className="text-sm text-gray-600">Uploading image...</p>
+          <div className="flex flex-col items-center space-y-2">
+            <Upload className="w-8 h-8 text-gray-400" />
+            <div>
+              <p className="text-sm font-medium text-gray-900">
+                Click to choose an image, or drag one here
+              </p>
+              <p className="text-xs text-gray-500">
+                PNG, JPG, WebP or GIF (large images are compressed automatically when you submit)
+              </p>
             </div>
-          ) : (
-            <div className="flex flex-col items-center space-y-2">
-              <Upload className="w-8 h-8 text-gray-400" />
-              <div>
-                <p className="text-sm font-medium text-gray-900">
-                  Click to upload or drag and drop
-                </p>
-                <p className="text-xs text-gray-500">
-                  PNG, JPG, WebP or GIF (large images are compressed automatically)
-                </p>
-              </div>
-            </div>
-          )}
+          </div>
         </div>
       )}
 
-      {/* Error message */}
-      {error && (
+      {pickError && (
         <div className="flex items-center space-x-2 text-sm text-red-600 bg-red-50 p-2 rounded">
-          <AlertCircle className="w-4 h-4" />
-          <span>{error}</span>
+          <AlertCircle className="w-4 h-4 flex-shrink-0" />
+          <span>{pickError}</span>
         </div>
       )}
 
-      {/* Hidden file input */}
       <Input
         type="file"
         ref={fileInputRef}
         onChange={handleFileInputChange}
         accept="image/*"
         className="hidden"
-        disabled={disabled || uploading}
+        disabled={disabled}
       />
-
-      <p className="text-xs text-gray-500">
-        Your image will be automatically compressed and optimized for web display.
-      </p>
     </div>
   )
 }

--- a/src/contexts/ErrorContext.tsx
+++ b/src/contexts/ErrorContext.tsx
@@ -17,8 +17,10 @@ interface ErrorContextType {
   // Handle authentication errors
   handleAuthError: (error: unknown, customMessage?: string) => void
   
-  // Handle form submission errors
-  handleFormError: (error: unknown, formName?: string) => void
+  // Handle form submission errors. `extra` is forwarded to Sentry as
+  // structured context (stage, mode, image kind, etc.) so we can debug
+  // failed submissions without rerunning the user's flow.
+  handleFormError: (error: unknown, formName?: string, extra?: Record<string, unknown>) => void
   
   // Show success message
   showSuccess: (message: string, description?: string) => void
@@ -117,13 +119,14 @@ export const ErrorProvider = ({ children }: ErrorProviderProps) => {
 
   const handleFormError = useCallback((
     error: unknown,
-    formName: string = 'form'
+    formName: string = 'form',
+    extra?: Record<string, unknown>
   ) => {
     const message = getErrorMessage(error)
     if (import.meta.env.DEV) {
-      console.error(`Form error in ${formName}:`, error)
+      console.error(`Form error in ${formName}:`, error, extra)
     }
-    captureError(error, { operation: formName })
+    captureError(error, { operation: formName, extra })
 
     showToast.error(`${formName} error`, {
       description: message,


### PR DESCRIPTION
Three structural UX changes to the project submission flow, motivated by production data showing students uploading the same image multiple times without ever creating a project row.

## Changes

### 1. Defer image upload to form submit (the big one)

`ImageUpload` is now a pure controlled picker with no network calls:

```ts
type ImagePickerValue =
  | { kind: 'empty' }
  | { kind: 'existing'; url: string }   // edit mode — original server URL
  | { kind: 'pending'; file: File }     // newly picked, not yet uploaded
  | { kind: 'cleared' }                 // edit mode — original removed by user
```

Pending state shows a local `URL.createObjectURL` preview labelled **"Will upload when you submit"**, with the object URL properly revoked on unmount/change. The compress + upload chain now lives inside `ProjectForm`'s submit handler, gated by the form-validation pass and chained to the project insert/update.

Effects:
- "Image uploaded but no project row" becomes mechanically impossible — they're the same action.
- Edit-mode three-state image (keep / replace / clear) is now explicit instead of being shoved through a single `string` slot.
- Closing the tab mid-flow no longer leaves orphan files in storage.

### 2. Stage-by-stage progress text on the submit button

The submit button label cycles through the actual stage instead of a generic spinner:

> Submit Project → **Preparing image… → Uploading image… → Saving project…**

Per Codex review feedback: a single generic spinner on a 30-second mobile submit looks frozen.

### 3. Inline persistent error display + missing-fields hint

- Submit failures render a persistent red error block **above the submit button** (toasts auto-dismiss; students were missing them). Copy explicitly says *"your form is intact, please try again"* so they don't refresh and lose their work.
- After the first failed validation attempt, an amber banner near the button lists missing fields by friendly name — `react-hook-form` already renders per-field errors but those can be off-screen on long forms.

## Edge cases handled

- **Edit mode** with three distinct image states: keep existing URL, replace with new File, clear. The old code conflated all three into a single `imageUrl: string`.
- **Object URL leaks** — `useEffect` cleanup revokes blob URLs on every state transition.
- **Double-click submit** — button stays `disabled={isSubmitting}`; per-attempt unique storage paths (`Date.now()` + random) defend against any concurrent attempt landing the same path.
- **Form state on failure** — `react-hook-form` already preserves field values on submit error. Verified the inline error path doesn't `reset()`.

## Out of scope (deliberate)

Codex flagged these for follow-up; not in this PR:
- localStorage form-draft persistence for "tab closed mid-edit"
- Sentry/PostHog instrumentation so we stop debugging by SQL forensics
- Always-write-a-draft-row pattern (too much new state machinery for the actual problem)

## Verification

- `npm run type-check` ✓
- `npm run build` ✓
- `npm run lint` ✓
- Manual browser test on Vercel preview to follow

## Related

Builds on:
- #78 (timeouts + Cache-Control fix)
- #79 (WebP re-encoding)
- #80 (raw input cap)