### PR TITLE
feat(observability): wire Sentry for client error tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,11 @@ VITE_SUPABASE_ANON_KEY=your-anon-key-here
 # VITE_POSTHOG_KEY=your-posthog-key
 # VITE_POSTHOG_HOST=https://app.posthog.com
 
+# Optional: Sentry error tracking (production only — Sentry no-ops in dev)
+# Get a DSN from https://sentry.io for the illinihunt project.
+# VITE_SENTRY_DSN=https://<key>@<org>.ingest.sentry.io/<project>
+
+
 # Development Notes:
 # 1. Copy this file to .env.local
 # 2. Replace the placeholder values with your actual Supabase credentials

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-toast": "^1.2.14",
+        "@sentry/react": "^10.51.0",
         "@supabase/supabase-js": "^2.45.0",
         "@types/dompurify": "^3.0.5",
         "@vercel/speed-insights": "^1.2.0",
@@ -2718,6 +2719,97 @@
         "win32"
       ]
     },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.51.0.tgz",
+      "integrity": "sha512-lNKBS4P7RUvf1niojXQWe9bU3gnBUCbST4Dj0pSiyat1N96cXVyHkeE+uGxowD0RrVWhs+kGHiVX3FcmRWF6sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.51.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.51.0.tgz",
+      "integrity": "sha512-bCM95bcpphx28e6aU0bwRLxOgwosYsdNzezM1sM0pVOkb0TB3hDFRamramVDK+/Hp1o8qmRxS4c5w/A7YBZGkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.51.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.51.0.tgz",
+      "integrity": "sha512-jCpI5HXSwK6ZT2HX70+mDRciAocHzSiDk4DTgvzV69Wvd+Ei5WLgE+d39eaEPsm8lUC0Ydntb5sJIB6uG9D4bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.51.0",
+        "@sentry/core": "10.51.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.51.0.tgz",
+      "integrity": "sha512-8PW1Pp+Yl3lPwYqhBCr5SgkuhDanu9ZLzUqD2bPKL/ElqbM2eDVIWxq4z4ZzePrmZa6IcCjTv6sVQJ7Z4dLyLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.51.0",
+        "@sentry/core": "10.51.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.51.0.tgz",
+      "integrity": "sha512-Zdc0sKfenxUtW/OGhtJ7xHFN44bXR7YqxJ1zBDzlZfW0nTbeTTUZBq9z5NUw6qdS0Vs/i3V4qzAKTbRKWfqSEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.51.0",
+        "@sentry-internal/feedback": "10.51.0",
+        "@sentry-internal/replay": "10.51.0",
+        "@sentry-internal/replay-canvas": "10.51.0",
+        "@sentry/core": "10.51.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.51.0.tgz",
+      "integrity": "sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.51.0.tgz",
+      "integrity": "sha512-RRHHqjNvjji6ebIqdlAr453AkST8Vm4cxdu1vWm772IgbzTO7Jx46Cj6Bt2/GjMyH0YLE5euDaAOQhFMmpvAOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.51.0",
+        "@sentry/core": "10.51.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
     "node_modules/@supabase/auth-js": {
       "version": "2.71.1",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
@@ -4117,17 +4209,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
@@ -5317,237 +5398,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lilconfig": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-toast": "^1.2.14",
+    "@sentry/react": "^10.51.0",
     "@supabase/supabase-js": "^2.45.0",
     "@types/dompurify": "^3.0.5",
     "@vercel/speed-insights": "^1.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,8 +91,15 @@ const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
 }
 
 function AppContent() {
-  const { user, error, loading, retryAuth } = useAuth()
+  const { user, profile, error, loading, retryAuth } = useAuth()
   const { isAdmin } = useAdminAuth()
+
+  // Tag Sentry events with the current user (id + username only, no PII)
+  useEffect(() => {
+    void import('@/lib/sentry').then(({ setSentryUser }) => {
+      setSentryUser(user ? { id: user.id, username: profile?.username ?? null } : null)
+    })
+  }, [user, profile])
 
   // Show error state with retry option if auth fails
   if (error && error.includes('timed out')) {

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import { Component, ReactNode } from 'react'
 import { AlertTriangle, Copy, RotateCcw, Home } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { captureError } from '@/lib/sentry'
 
 interface Props {
   children: ReactNode
@@ -44,6 +45,15 @@ export class ErrorBoundary extends Component<Props, State> {
       console.error('URL:', window.location.href)
       console.groupEnd()
     }
+
+    captureError(error, {
+      operation: 'react-render',
+      extra: {
+        componentStack: errorInfo.componentStack,
+        errorId: this.state.errorId,
+        url: window.location.href,
+      },
+    })
 
     this.setState({ errorInfo })
   }

--- a/src/contexts/ErrorContext.tsx
+++ b/src/contexts/ErrorContext.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react-refresh/only-export-components */
 import { createContext, useContext, ReactNode, useCallback, useMemo } from 'react'
 import { showToast, getErrorMessage } from '@/components/ui/toast'
+import { captureError } from '@/lib/sentry'
 
 interface ErrorContextType {
   // Handle different types of errors with appropriate UI feedback
@@ -55,7 +56,8 @@ export const ErrorProvider = ({ children }: ErrorProviderProps) => {
     if (import.meta.env.DEV) {
       console.error(`Error in ${context}:`, error)
     }
-    
+    captureError(error, { operation: context })
+
     // Show to user unless explicitly disabled
     if (options.showToUser !== false) {
       showToast.error(`Failed to ${context}`, {
@@ -68,7 +70,7 @@ export const ErrorProvider = ({ children }: ErrorProviderProps) => {
   }, [])
 
   const handleServiceError = useCallback((
-    error: unknown, 
+    error: unknown,
     operation: string,
     retry?: () => void
   ) => {
@@ -76,6 +78,7 @@ export const ErrorProvider = ({ children }: ErrorProviderProps) => {
     if (import.meta.env.DEV) {
       console.error(`Service error during ${operation}:`, error)
     }
+    captureError(error, { operation })
     
     // Check if it's a network error
     if (message.toLowerCase().includes('network') || 
@@ -120,7 +123,8 @@ export const ErrorProvider = ({ children }: ErrorProviderProps) => {
     if (import.meta.env.DEV) {
       console.error(`Form error in ${formName}:`, error)
     }
-    
+    captureError(error, { operation: formName })
+
     showToast.error(`${formName} error`, {
       description: message,
       debugInfo: import.meta.env.DEV ? JSON.stringify(error) : undefined,

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -1,0 +1,65 @@
+import * as Sentry from '@sentry/react'
+
+/**
+ * Initialize Sentry. No-op in dev, or when VITE_SENTRY_DSN is not set
+ * (e.g., a local production build with no DSN configured).
+ *
+ * Privacy note: we deliberately do NOT enable Session Replay or capture
+ * email/full_name. Only the user's UUID and username are attached so we
+ * can correlate an error to a specific student without storing PII.
+ */
+export function initSentry(): void {
+  const dsn = import.meta.env.VITE_SENTRY_DSN
+
+  if (!dsn || !import.meta.env.PROD) {
+    return
+  }
+
+  Sentry.init({
+    dsn,
+    environment: import.meta.env.MODE,
+
+    // Performance tracing — keep low to control quota. Bump for short
+    // investigation windows by setting this higher in env.
+    tracesSampleRate: 0.05,
+
+    // Capture browser console errors and unhandled rejections
+    integrations: [
+      Sentry.browserTracingIntegration(),
+    ],
+
+    // Filter noisy known-benign errors before they hit the wire
+    beforeSend(event, hint) {
+      const error = hint.originalException
+      if (error instanceof Error) {
+        // Browser extensions / chrome-extension:// origins
+        if (error.message.includes('ResizeObserver loop')) return null
+        if (error.message.includes('Non-Error promise rejection')) return null
+      }
+      return event
+    },
+  })
+}
+
+/**
+ * Attach the current user to Sentry's scope, or clear it on sign-out.
+ * Caller is responsible for invoking this when auth state changes.
+ */
+export function setSentryUser(user: { id: string; username?: string | null } | null): void {
+  if (user) {
+    Sentry.setUser({ id: user.id, username: user.username ?? undefined })
+  } else {
+    Sentry.setUser(null)
+  }
+}
+
+/**
+ * Capture an exception with optional context. Used by ErrorContext so
+ * every toast surface ALSO produces a Sentry event we can investigate.
+ */
+export function captureError(error: unknown, context?: { operation?: string; extra?: Record<string, unknown> }): void {
+  Sentry.captureException(error, {
+    tags: context?.operation ? { operation: context.operation } : undefined,
+    extra: context?.extra,
+  })
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,10 @@ import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
 import { ensureSupabaseInitialized } from './lib/supabaseInit'
+import { initSentry } from './lib/sentry'
+
+// Initialize observability before anything else so init failures are captured
+initSentry()
 
 // Validate required environment variables before app initialization
 // This provides a user-friendly error instead of a blank page


### PR DESCRIPTION
We've been debugging upload/submit failures by reading rows out of `storage.objects` and `public.projects` to figure out which step a student got stuck on. That doesn't scale and only works after-the-fact for users who left a paper trail. Sentry gives us actual stack traces, the user's session, and breadcrumbs for what they did before the error fired.

Worth landing **before** PR #81 (the deferred-upload refactor) so we can see how the new flow behaves with real users from day one.

## Wiring

- New **`src/lib/sentry.ts`** with three small helpers: `initSentry` (idempotent no-op in dev or when `VITE_SENTRY_DSN` isn't set), `setSentryUser` (id + username only — deliberately no email/full_name/PII), and `captureError` (used by ErrorContext).
- **`main.tsx`** calls `initSentry()` before app render so init failures are themselves captured.
- **`AppContent`** runs a `useEffect` that pushes the current `user.id` + `profile.username` into Sentry's scope on auth changes, so errors are correlated to a specific student without storing personal data.
- **`ErrorContext`** — `handleError`, `handleServiceError`, and `handleFormError` each forward their error to `captureError` with an `operation` tag. Toast surface unchanged; Sentry is purely additional.
- **`ErrorBoundary.componentDidCatch`** forwards React render errors with `componentStack` and `url` as extras.
- **`.env.example`** documents `VITE_SENTRY_DSN`.

## Privacy posture

- No Session Replay (would capture form input).
- No email or full_name attached.
- Only `id` + `username` on the user object; tag is a short operation name.
- `beforeSend` filter drops two known-benign noise classes: `ResizeObserver loop` violations and `Non-Error promise rejection` warnings.

## Production-only

Gated by **both** `import.meta.env.PROD` AND a configured DSN. Local dev never reports. Local production builds without `VITE_SENTRY_DSN` also no-op. This means the bundle ships the SDK code in dev too (we don't dynamic-import to avoid an extra request) but it never connects.

## Bundle impact

~10 kB on the entry chunk; ~42 kB on `utils-vendor`. ~14 kB gzipped total. Acceptable for the visibility gain.

## Operator setup (must happen separately from this PR landing)

1. Create a JS project at sentry.io for illinihunt.
2. Copy the DSN.
3. Add `VITE_SENTRY_DSN` to Vercel: production AND preview environments.
4. Trigger a known error in production to verify events arrive.

## Verification

- `npm run type-check` ✓
- `npm run build` ✓
- `npm run lint` ✓

## Note on package-lock.json

The lockfile diff is large (~330 lines) but it's almost entirely `@sentry/*` sub-package additions plus the same `lightningcss-*` optional native binary drift we've seen in earlier PRs (npm pruning entries that don't match the host platform during `npm install`). Vercel's Linux build will re-add the Linux variants automatically.