### PR TITLE
fix(csp): allow Sentry ingest hosts in connect-src

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -37,7 +37,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; img-src 'self' https: data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://vercel.live https://static.cloudflareinsights.com; script-src-elem 'self' 'unsafe-inline' 'unsafe-eval' https://vercel.live https://static.cloudflareinsights.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://vercel.live https://cloudflareinsights.com; frame-src 'self' https://vercel.live https://www.youtube.com; worker-src 'self' blob:;"
+          "value": "default-src 'self'; img-src 'self' https: data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://vercel.live https://static.cloudflareinsights.com; script-src-elem 'self' 'unsafe-inline' 'unsafe-eval' https://vercel.live https://static.cloudflareinsights.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://vercel.live https://cloudflareinsights.com https://*.ingest.sentry.io https://*.ingest.us.sentry.io; frame-src 'self' https://vercel.live https://www.youtube.com; worker-src 'self' blob:;"
         },
         {
           "key": "Referrer-Policy",


### PR DESCRIPTION
The CSP in `vercel.json` blocked Sentry's `POST` to `*.ingest.us.sentry.io`. Visible in the production browser console as:

> Refused to connect because it violates the document's Content Security Policy.

Result: Sentry SDK initialized fine, but no events ever shipped — silent observability failure right after #82 landed.

## Fix

Adds two patterns to `connect-src`:

```
https://*.ingest.sentry.io https://*.ingest.us.sentry.io
```

Both regional patterns because Sentry can route a project through different regional ingest endpoints — current DSN points at `us`, but if we ever migrate or add a second project the non-regional pattern catches it.

## Verification

- After deploy, Sentry events from production will arrive within seconds of any error.
- CSP report-only would tell us about violations earlier; not adding it in this PR but worth considering as a follow-up.