### PR TITLE
fix(project-team): disambiguate users join in getProjectMembers

### DIFF
--- a/src/lib/services/projects.ts
+++ b/src/lib/services/projects.ts
@@ -294,11 +294,13 @@ export class ProjectsService {
   }
 
   static async getProjectMembers(projectId: string) {
+    // project_members has two FKs to users (user_id and invited_by); pick the
+    // member relationship explicitly so PostgREST doesn't 300 on ambiguity.
     return supabase
       .from('project_members')
       .select(`
         *,
-        users (
+        users!project_members_user_id_fkey (
           id,
           username,
           full_name,


### PR DESCRIPTION
## Bug

`ProjectsService.getProjectMembers` was returning HTTP 300 ("Multiple Choices") from PostgREST. The Project Team section appeared to work because the page falls back to the creator embedded in the main project record, but the dedicated members query was always failing silently.

## Cause

\`project_members\` has **two** foreign keys into \`users\`:
- \`project_members_user_id_fkey\` — the team member
- \`project_members_invited_by_fkey\` — who invited them

The select used the generic \`users(...)\` embed shape, which PostgREST refuses when more than one relationship matches and returns 300.

## Fix

One-line change: pin the embed to the member relationship.

\`\`\`diff
- users (
+ users!project_members_user_id_fkey (
\`\`\`

The other two project-team queries (\`getProjectInvitations\`, \`getPendingInvitationsForCurrentUser\`) were already using the explicit-FK form correctly. This brings \`getProjectMembers\` in line.

## Verification

- \`npm run type-check\` ✓
- \`npm run build\` ✓
- After deploy, the Project Team section's network request should return 200 instead of 300, and the section will populate from the dedicated query rather than the fallback.