### PR TITLE
fix(sentry): static import setSentryUser

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { LoadingSpinner } from '@/components/shared/LoadingSpinner'
 import { AuthProvider } from '@/contexts/AuthContext'
 import { RealtimeVotesProvider } from '@/contexts/RealtimeVotesContext'
 import { GitHubPopupButton } from '@/components/GitHubPopupButton'
+import { setSentryUser } from '@/lib/sentry'
 
 // Lazy load all pages for code splitting
 const HomePage = lazy(() => import('@/pages/HomePage').then(module => ({ default: module.HomePage })))
@@ -96,9 +97,7 @@ function AppContent() {
 
   // Tag Sentry events with the current user (id + username only, no PII)
   useEffect(() => {
-    void import('@/lib/sentry').then(({ setSentryUser }) => {
-      setSentryUser(user ? { id: user.id, username: profile?.username ?? null } : null)
-    })
+    setSentryUser(user ? { id: user.id, username: profile?.username ?? null } : null)
   }, [user, profile])
 
   // Show error state with retry option if auth fails


### PR DESCRIPTION
Replaces dynamic `import('@/lib/sentry')` in App.tsx with a static import. Vite was warning that the dynamic form didn't actually split the chunk (sentry.ts is statically imported by main.tsx already), so the indirection produced no benefit and added a build warning.