### PR TITLE
fix(spa): auto-recover from stale lazy chunks after a deploy

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,24 @@ import { initSentry } from './lib/sentry'
 // Initialize observability before anything else so init failures are captured
 initSentry()
 
+// Recover from stale lazy-loaded chunks after a deploy. Vite emits this event
+// when an `import()` call resolves to a content-hashed asset that no longer
+// exists (the user's tab was open across a deploy and the new build replaced
+// the chunk with a different hash). One-time reload picks up the fresh index
+// HTML, which references current chunk URLs. Guard with sessionStorage so a
+// genuinely-broken deploy doesn't put the user in a refresh loop.
+window.addEventListener('vite:preloadError', (event) => {
+  const RELOAD_FLAG = 'illinihunt:preload-error-reloaded'
+  if (sessionStorage.getItem(RELOAD_FLAG)) {
+    // Already tried once this session — let the error surface so we see it
+    // in Sentry rather than spinning indefinitely.
+    return
+  }
+  event.preventDefault()
+  sessionStorage.setItem(RELOAD_FLAG, '1')
+  window.location.reload()
+})
+
 // Validate required environment variables before app initialization
 // This provides a user-friendly error instead of a blank page
 const requiredEnvVars = ['VITE_SUPABASE_URL', 'VITE_SUPABASE_ANON_KEY'] as const


### PR DESCRIPTION
Sentry showed two real users today hitting "Failed to fetch dynamically imported module" / "Importing a module script failed" — the standard SPA pain when a tab is open across a deploy and a lazy chunk's hashed URL is no longer valid.

Vite emits a `vite:preloadError` event for this. One-time reload picks up the fresh `index.html` (with current chunk URLs). `sessionStorage` guard prevents a refresh loop on a genuinely broken deploy — second occurrence in the same tab falls through to the original error so it still surfaces in Sentry.

## Verification
- `npm run type-check` ✓
- `npm run build` ✓
- Hard to test locally without a real deploy; Vite's dev server doesn't trigger the event.