### PR TITLE
feat(observability): instrument silent submit funnel dead-ends

### DIFF
--- a/src/components/project/ProjectForm.tsx
+++ b/src/components/project/ProjectForm.tsx
@@ -7,6 +7,7 @@ import { useCategories } from '@/hooks/useCategories'
 import { useError } from '@/contexts/ErrorContext'
 import { ProjectsService } from '@/lib/database'
 import { compressImage, uploadProjectImage } from '@/lib/imageUpload'
+import { captureFunnelEvent } from '@/lib/sentry'
 import { projectSchema, type ProjectFormData } from '@/lib/validations'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -206,7 +207,20 @@ export function ProjectForm({ mode = 'create', projectId, initialData, onSuccess
         </p>
       </div>
 
-      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+      <form
+        onSubmit={handleSubmit(onSubmit, (validationErrors) => {
+          // Submit clicked but client-side validation failed. The user sees
+          // inline errors next to each field plus the missing-fields banner,
+          // but they may not notice on a long form. Logging this lets us see
+          // silent dead-ends in the funnel that never reach the server.
+          captureFunnelEvent('submit-validation-failed', {
+            mode,
+            missingFields: Object.keys(validationErrors),
+            imageKind: image.kind,
+          })
+        })}
+        className="space-y-6"
+      >
         {/* Project Name */}
         <div className="space-y-2">
           <Label htmlFor="name">Project Name *</Label>

--- a/src/components/ui/ImageUpload.tsx
+++ b/src/components/ui/ImageUpload.tsx
@@ -4,6 +4,7 @@ import { Input } from './input'
 import { Label } from './label'
 import { Upload, X, AlertCircle } from 'lucide-react'
 import { RAW_INPUT_MAX_BYTES } from '@/lib/imageUpload'
+import { captureFunnelEvent } from '@/lib/sentry'
 
 /**
  * The image input is a *deferred* picker: it never uploads. The parent
@@ -45,11 +46,13 @@ export function ImageUpload({ value, onChange, disabled }: ImagePickerProps) {
     setPickError(null)
     if (!ALLOWED_TYPES.includes(file.type)) {
       setPickError('Please choose a JPG, PNG, WebP, or GIF.')
+      captureFunnelEvent('image-pick-rejected', { reason: 'mime', mime: file.type, size: file.size })
       return
     }
     if (file.size > RAW_INPUT_MAX_BYTES) {
       const mb = Math.round(RAW_INPUT_MAX_BYTES / (1024 * 1024))
       setPickError(`Image is too large. Please choose a file under ${mb} MB — it will be compressed automatically when you submit.`)
+      captureFunnelEvent('image-pick-rejected', { reason: 'size', mime: file.type, size: file.size })
       return
     }
     onChange({ kind: 'pending', file })

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -86,6 +86,21 @@ function toError(error: unknown): { error: Error; supabaseFields?: Record<string
 }
 
 /**
+ * Lightweight info-level event for instrumenting funnel steps that
+ * don't throw — e.g., a submit attempt that fails client-side validation
+ * and never reaches the network. Lets us see silent dead-ends in the
+ * issue feed alongside real errors. Use sparingly; high-frequency events
+ * burn the free-tier quota.
+ */
+export function captureFunnelEvent(name: string, extra?: Record<string, unknown>): void {
+  Sentry.captureMessage(name, {
+    level: 'info',
+    tags: { funnel: name },
+    extra,
+  })
+}
+
+/**
  * Capture an exception with optional context. Used by ErrorContext so
  * every toast surface ALSO produces a Sentry event we can investigate.
  */


### PR DESCRIPTION
## Why

Students reported submission issues yesterday afternoon, 9 hours after the deferred-upload + Sentry stack landed. **Sentry caught zero events**, **`storage.objects` saw zero new uploads**, and **`public.projects` saw zero new rows** during that window. They never reached any throwing code path — they got stuck somewhere quieter than what we currently log.

## Two silent gates likely behind the reports

1. **Submit clicked, Zod validation rejected.** `react-hook-form`'s `handleSubmit` short-circuits before `onSubmit` runs. Inline field errors and the missing-fields banner are shown, but on a long mobile form they can be off-screen. Nothing throws.

2. **Picked file rejected at pre-flight.** Wrong MIME or > 25 MB → `setPickError` shows a red message under the dropzone. Nothing throws.

Either of those = student gives up = Sentry blind.

## What this PR adds

- New `captureFunnelEvent(name, extra)` helper in `src/lib/sentry.ts`. Emits an **info-level** Sentry message tagged `funnel:<name>`. Info-level keeps these out of the error feed, but they're queryable.

- ProjectForm wires the second arg of `handleSubmit` (the validation-failure callback) to fire `submit-validation-failed` with `{ missingFields, mode, imageKind }`.

- ImageUpload fires `image-pick-rejected` with `{ reason: 'mime'|'size', mime, size }` whenever a pick fails its pre-flight checks.

## Why messages, not breadcrumbs

Breadcrumbs only ship when an actual exception fires. If submit never fires, breadcrumbs never reach Sentry. `captureMessage` ships immediately — perfect for silent dead-ends.

## Verification

- `npm run type-check` ✓
- `npm run build` ✓
- `npm run lint` ✓
- After deploy, find these in Sentry by querying `funnel:submit-validation-failed` or `funnel:image-pick-rejected`.