### PR TITLE
feat(observability): instrument auth errors and form-mount funnel

### DIFF
--- a/src/components/project/ProjectForm.tsx
+++ b/src/components/project/ProjectForm.tsx
@@ -72,6 +72,14 @@ export function ProjectForm({ mode = 'create', projectId, initialData, onSuccess
     resolver: zodResolver(projectSchema)
   })
 
+  // Funnel: capture once that the form actually mounted in this user's
+  // browser. Lets us tell apart "they never reached /submit" from "they
+  // reached it but never clicked submit." Fires once per mount.
+  useEffect(() => {
+    captureFunnelEvent('project-form-mounted', { mode })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   // Populate form with initial data for edit mode
   useEffect(() => {
     if (mode === 'edit' && initialData) {

--- a/src/contexts/ErrorContext.tsx
+++ b/src/contexts/ErrorContext.tsx
@@ -104,10 +104,20 @@ export const ErrorProvider = ({ children }: ErrorProviderProps) => {
     if (import.meta.env.DEV) {
       console.error('Authentication error:', error)
     }
-    
+
+    // Forward to Sentry tagged operation:auth so we can see auth failures
+    // alongside other errors. Skip the @illinois.edu domain rejection — that's
+    // expected user behavior, not an error worth a Sentry event.
+    if (!message.toLowerCase().includes('@illinois.edu')) {
+      captureError(error, {
+        operation: 'auth',
+        extra: customMessage ? { customMessage } : undefined,
+      })
+    }
+
     if (customMessage) {
       showToast.authError(customMessage)
-    } else if (message.toLowerCase().includes('permission') || 
+    } else if (message.toLowerCase().includes('permission') ||
                message.toLowerCase().includes('unauthorized')) {
       showToast.authError('Permission denied')
     } else if (message.toLowerCase().includes('@illinois.edu')) {


### PR DESCRIPTION
Two gaps in our Sentry coverage that the May 7 student reports exposed:

## Gap 1: auth errors invisible to Sentry

`handleAuthError` did not call `captureError`. If a student's Google OAuth flow fails, the toast fires client-side and Sentry sees nothing. Now forwarded with `operation: auth` tag.

Skipping the `@illinois.edu` domain-rejection path — that's expected user behavior (someone trying with a personal Gmail), not worth burning quota on.

## Gap 2: no event for 'form rendered successfully'

We instrument what fails inside the form, but had no signal for whether students actually reach the form. So we can't tell apart:

- "User never made it to /submit" (auth/routing/chunk-load failure)
- "User reached /submit but never clicked Submit" (UX failure)

Added a one-shot `project-form-mounted` info event in a mount-only `useEffect`. Now the funnel reads: form-mounted → [pick or skip image] → submit-validation-failed → [throws land as error events with stage] → success.

## Why this matters now

May 7 morning: 4 of 5 known-troubled students still have 0 projects, 0 new signups in 24h, students reporting issues, but Sentry shows zero new events and zero funnel events. The most likely explanation is they're failing **before** reaching anything we currently instrument — auth or form-mount being the obvious candidates.

## Verification

- `npm run type-check` ✓
- `npm run build` ✓
- `npm run lint` ✓