### PR TITLE
feat(observability): close the funnel gap between form-mount and error

### DIFF
--- a/src/components/project/ProjectForm.tsx
+++ b/src/components/project/ProjectForm.tsx
@@ -106,6 +106,13 @@ export function ProjectForm({ mode = 'create', projectId, initialData, onSuccess
       return
     }
 
+    // Funnel: passed Zod validation and started the actual submit chain.
+    // Pairs with submit-validation-failed; together they cover every click.
+    captureFunnelEvent('submit-attempt-validated', {
+      mode,
+      imageKind: image.kind,
+    })
+
     setSubmitError(null)
     setIsSubmitting(true)
     setStage(null)

--- a/src/components/ui/ImageUpload.tsx
+++ b/src/components/ui/ImageUpload.tsx
@@ -55,6 +55,7 @@ export function ImageUpload({ value, onChange, disabled }: ImagePickerProps) {
       captureFunnelEvent('image-pick-rejected', { reason: 'size', mime: file.type, size: file.size })
       return
     }
+    captureFunnelEvent('image-picked', { mime: file.type, size: file.size })
     onChange({ kind: 'pending', file })
   }
 


### PR DESCRIPTION
## Why

Sentry showed two previously-stuck students (aflasck2, mjdiaz3) reached `/submit` on May 10 — `project-form-mounted` events fired — and then **nothing else**. No project created, no upload, no error, no funnel event.

Existing instrumentation only captured the *negative* paths after form-mount: `pick-rejected`, `submit-validation-failed`, `error`. So a student who picked a valid file or clicked Submit and passed validation produced zero signal until something errored.

Both students sat in that blind spot today.

## What this PR adds

Two info-level funnel events:

- **`image-picked`** — fires when `validateAndPick` accepts a file. Paired with the existing `image-pick-rejected`, every file selection now produces exactly one event.
- **`submit-attempt-validated`** — fires at the start of `onSubmit`, after Zod validation has passed. Paired with the existing `submit-validation-failed`, every Submit click now produces exactly one event.

## Resulting funnel

Every step has a Sentry signal (success or failure) so we can see drop-off precisely:

```
form-mounted
  ↓
image-picked | image-pick-rejected | (no image: skip step)
  ↓
submit-attempt-validated | submit-validation-failed
  ↓
[error event with stage] | (success: project row appears in DB)
```

A user who shows at `form-mounted` but never at the next step **clearly bailed without trying**. That's the actionable signal we don't have today.

## Verification

- `npm run type-check` ✓
- `npm run build` ✓
- `npm run lint` ✓