### PR TITLE
fix(api): stop unhandled async rejections from crashing the API (unauth /users/:id DoS)

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -14,6 +14,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.1",
+        "express-async-errors": "^3.1.1",
         "express-rate-limit": "^7.4.1",
         "jsonwebtoken": "^9.0.2",
         "jwks-rsa": "^3.1.0",
@@ -65,6 +66,7 @@
       "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
       "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.10.0",
@@ -126,6 +128,7 @@
       "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.23.0.tgz",
       "integrity": "sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.10.0",
@@ -695,6 +698,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -716,6 +720,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
       "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -752,6 +757,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
       "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.57.2",
         "@types/shimmer": "^1.2.0",
@@ -1282,6 +1288,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
       "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -1715,6 +1722,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2096,6 +2104,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
       "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -2135,6 +2144,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-async-errors": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/express-async-errors/-/express-async-errors-3.1.1.tgz",
+      "integrity": "sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==",
+      "license": "ISC",
+      "peerDependencies": {
+        "express": "^4.16.2"
       }
     },
     "node_modules/express-rate-limit": {
@@ -2929,6 +2947,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/engines": "5.22.0"
       },

--- a/api/package.json
+++ b/api/package.json
@@ -21,6 +21,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.1",
+    "express-async-errors": "^3.1.1",
     "express-rate-limit": "^7.4.1",
     "jsonwebtoken": "^9.0.2",
     "jwks-rsa": "^3.1.0",

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -10,6 +10,10 @@ if (process.env.SENTRY_DSN) {
 }
 
 import express from 'express'
+// Patches Express 4 so rejected promises in async route handlers are forwarded
+// to errorHandler instead of becoming an unhandledRejection (which crashes the
+// Node process under Node 22). Must be imported before routers handle requests.
+import 'express-async-errors'
 import cors from 'cors'
 import rateLimit from 'express-rate-limit'
 

--- a/api/src/routes/users.ts
+++ b/api/src/routes/users.ts
@@ -7,6 +7,11 @@ import { isAdminEmail } from '../middleware/requireAdmin.js'
 
 const router = Router()
 
+// users.id is a Postgres UUID column. A non-UUID :id (e.g. an unmatched
+// /api/users/me falling through to /:id) makes Prisma throw P2023, so reject
+// early with 404 instead of pushing a malformed value into the query.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
 // GET /api/users/search?q=... — used by the invitation flow
 router.get('/search', requireAuth, async (req, res) => {
   const q = String(req.query.q ?? '').trim()
@@ -137,6 +142,7 @@ router.put('/me', requireAuth, async (req, res) => {
 // GET /api/users/:id/projects — owned + member-on projects
 router.get('/:id/projects', async (req, res) => {
   const userId = req.params.id!
+  if (!UUID_RE.test(userId)) return res.status(404).json({ error: 'User not found' })
 
   const [owned, memberships] = await Promise.all([
     prisma.projects.findMany({
@@ -172,6 +178,7 @@ router.get('/:id/projects', async (req, res) => {
 
 // GET /api/users/:id — public profile (placed last because /search and /me would match)
 router.get('/:id', async (req, res) => {
+  if (!UUID_RE.test(req.params.id!)) return res.status(404).json({ error: 'User not found' })
   const user = await prisma.users.findUnique({
     where: { id: req.params.id! },
     select: {


### PR DESCRIPTION
## Problem

The Azure App Service container (`illinihunt-api`) was crash-looping into **503**s. Root cause from the container logs:

```
PrismaClientKnownRequestError (P2023) at dist/routes/users.js:169
Invalid `prisma.users.findUnique()` invocation:
Error creating UUID, invalid character ... found `m` at 1
→ Node.js v22.22.3   (process exits)
```

Two bugs, one systemic:

1. **Unauthenticated crash.** There is no `GET /api/users/me` route (only `/me/is-admin`, `/me/interactions`, `/me/invitations`, `PUT /me`). A `GET /api/users/me` falls through to `GET /:id` → `prisma.users.findUnique({ where: { id: "me" }})`. `users.id` is a UUID column, so Prisma throws `P2023`. **No auth required** — any `GET /api/users/<non-uuid>` reproduces it.

2. **Systemic (why it crashed instead of 500ing).** In Express 4 a rejected promise in an `async` handler is **not** routed to `errorHandler` — it becomes an `unhandledRejection`, which Node 22 turns into a **process exit**. So the existing `errorHandler` (which would have returned a clean 500) never ran, and *any* async DB error in *any* route could take the whole API down.

This is an availability/DoS bug: an anonymous client could crash the backend on demand (App Service auto-restarts via `alwaysOn`, ~35s 503 window each time).

## Fix

- **`import 'express-async-errors'`** in `index.ts` (before routers handle requests) so rejected promises in async handlers are forwarded to the existing `errorHandler` → clean 500 instead of a process crash. Covers every route, not just this one.
- **UUID guard** on the two unauthenticated `/:id` user routes (`GET /:id`, `GET /:id/projects`) → returns `404` before touching Prisma when the id isn't a UUID.

## Verification

- `npm run type-check` and `npm run build` pass.
- Local smoke test (built image entrypoint):
  - `GET /api/users/me` → `404 {"error":"User not found"}` (was the crasher)
  - `GET /api/users/not-a-uuid` → `404`
  - **server stays alive** after both (previously: process exit)
  - `GET /healthz` → `200`
- Production was restored separately via an App Service restart before this PR.

## Notes / follow-ups

- Other `:id` routes (projects, comments, collections, …) are now protected from *crashing* by the global async-error handling; they'll return `500` on a malformed UUID rather than `404`. Adding the same UUID guard there is an optional polish, not required for the availability fix.
- Deploy path: merging to `azure-migration` triggers `.github/workflows/azure-webapp-api.yml` → builds + pushes `illinihunt-api:latest` to ACR → App Service auto-pulls. So **merge = production deploy.**

Related: the apex `illinihunt.org` was cut over to Azure on 2026-06-08; `www` is still on Vercel pending #96.
